### PR TITLE
Use redux to keep track of questions state

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^2.8.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@reduxjs/toolkit": "^1.9.7",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -5274,6 +5275,29 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remix-run/router": {
@@ -21467,7 +21491,8 @@
     },
     "node_modules/react-redux": {
       "version": "8.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -21767,6 +21792,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "license": "MIT",
@@ -21980,6 +22021,11 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@chakra-ui/react": "^2.8.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@reduxjs/toolkit": "^1.9.7",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/components/QnFilter/QnFilter.component.tsx
+++ b/frontend/src/components/QnFilter/QnFilter.component.tsx
@@ -14,6 +14,7 @@ export const FilterBar = ({
   setFilter,
 }: FilterBarProps) => {
   const [txtFilter, setTextFilter] = useState(qnFilter);
+
   const filterChange = (event: React.FormEvent<HTMLInputElement>) => {
     setTextFilter((event.target as HTMLInputElement).value);
     const newFilter: QnFilter = {
@@ -23,8 +24,9 @@ export const FilterBar = ({
       titleAscd: titleAscd,
     };
 
-    if (onFilterChange) onFilterChange(newFilter);
+    if (setFilter) setFilter(newFilter);
   };
+
   return (
     <Flex w="80%" px="6" py="4" align={"center"} justify={"space-between"}>
       <HStack spacing="1">
@@ -32,7 +34,7 @@ export const FilterBar = ({
           variant="outline"
           placeholder={qnFilter || "Find Questions"}
           borderRadius="15"
-          onChange={(ev) => filterChange(ev)}
+          onChange={filterChange}
           value={txtFilter}
         ></Input>
       </HStack>

--- a/frontend/src/components/QnFilter/QnFilter.component.tsx
+++ b/frontend/src/components/QnFilter/QnFilter.component.tsx
@@ -2,8 +2,8 @@ import { Flex, HStack, Input } from "@chakra-ui/react";
 import { QnFilter } from "../../models/Quesiton.model";
 import React, { useState } from "react";
 
-export interface filterprop extends QnFilter {
-  onFilterChange?: (filter: QnFilter) => void; // refilters original db
+export interface FilterBarProps extends QnFilter {
+  setFilter : (filter: QnFilter) => void; // refilters original db
 }
 
 export const FilterBar = ({
@@ -11,8 +11,8 @@ export const FilterBar = ({
   tagFilter = new Set(),
   difficultyFilter = [0, 100],
   titleAscd = true,
-  onFilterChange,
-}: filterprop) => {
+  setFilter,
+}: FilterBarProps) => {
   const [txtFilter, setTextFilter] = useState(qnFilter);
   const filterChange = (event: React.FormEvent<HTMLInputElement>) => {
     setTextFilter((event.target as HTMLInputElement).value);

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { ChakraProvider } from "@chakra-ui/react"
+import { Provider } from 'react-redux';
+import store from './reducers/store';
 
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
     <ChakraProvider>
-      <App /> 
+      <Provider store={store}>
+        <App />
+      </Provider>
     </ChakraProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/BankPage/Bank.page.tsx
+++ b/frontend/src/pages/BankPage/Bank.page.tsx
@@ -1,52 +1,30 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { QnTable } from "../../components/QnTable/QnTable.component";
 import { FilterBar } from "../../components/QnFilter/QnFilter.component";
 import { VStack } from "@chakra-ui/react";
 import { QnFilter } from "../../models/Quesiton.model";
 import { Question } from "../../models/Quesiton.model";
 import { dummyQn } from "../../data/sampleqn";
+import { useDispatch, useSelector } from "react-redux";
+import { selectFilteredQuestions, setQuestions } from "../../reducers/questionsSlice";
+import { RootState } from "../../reducers/store";
 
-const filterQn = (questions: Question[], filter: QnFilter) => {
-  return questions.filter((qn) => {
-    if (filter.difficultyFilter) {
-      if (
-        qn.difficulty > filter.difficultyFilter[1] ||
-        qn.difficulty < filter.difficultyFilter[0]
-      )
-        return false;
-    }
-
-    if (filter.tagFilter && filter.tagFilter.size) {
-      if (qn.categories.every((tag) => !filter.tagFilter?.has(tag))) {
-        return false;
-      }
-    }
-
-    if (filter.qnFilter) {
-      if (qn.displayedQuestion.toLowerCase().indexOf(filter.qnFilter) === -1) {
-        return false;
-      }
-    }
-
-    return true;
-  });
-};
 
 const BankPage = () => {
-  const allQuestion = dummyQn;
-  const [filter, changeFilter] = useState<QnFilter>({});
-  const [filteredQn, setFilteredQn] = useState<Question[]>(
-    filterQn(allQuestion, filter)
-  );
-  const onFilterChange = (newFilter: QnFilter) => {
-    changeFilter(newFilter);
-    setFilteredQn(filterQn(allQuestion, newFilter));
-  };
+  const [filter, setFilter] = useState<QnFilter>({});
+  const filteredQns = useSelector((state : RootState) => selectFilteredQuestions(state, filter))
+  const dispatch = useDispatch();
+  
+  useEffect(() => {
+    console.log('dispatching...')
+    setTimeout(() => dispatch(setQuestions(dummyQn)), 3000) //simulating network fetch
+  }, [])
+
   return (
     <VStack spacing="3">
-      <FilterBar onFilterChange={onFilterChange} />
+      <FilterBar setFilter={setFilter} />
 
-      <QnTable filteredQn={filteredQn} pageSize={7}></QnTable>
+      <QnTable filteredQn={filteredQns} pageSize={7}></QnTable>
     </VStack>
   );
 };

--- a/frontend/src/reducers/questionsSlice.ts
+++ b/frontend/src/reducers/questionsSlice.ts
@@ -1,0 +1,45 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from './store';
+import { QnFilter, Question } from '../models/Quesiton.model';
+
+
+const questionsSlice = createSlice({
+    name: 'questions',
+    initialState: {
+        originalQuestions: [] as Question[]
+    },
+    reducers: {
+        setQuestions: (state, action) => {
+            state.originalQuestions = action.payload;
+        }
+    },
+});
+
+export const selectFilteredQuestions = (state: RootState, filter: QnFilter) => {
+    return state.questions.originalQuestions.filter((qn) => {
+        if (filter.difficultyFilter) {
+          if (
+            qn.difficulty > filter.difficultyFilter[1] ||
+            qn.difficulty < filter.difficultyFilter[0]
+          )
+            return false;
+        }
+    
+        if (filter.tagFilter && filter.tagFilter.size) {
+          if (qn.categories.every((tag) => !filter.tagFilter?.has(tag))) {
+            return false;
+          }
+        }
+    
+        if (filter.qnFilter) {
+          if (qn.displayedQuestion.toLowerCase().indexOf(filter.qnFilter) === -1) {
+            return false;
+          }
+        }
+    
+        return true;
+      });
+}
+
+export const { setQuestions } = questionsSlice.actions;
+export default questionsSlice.reducer;

--- a/frontend/src/reducers/store.ts
+++ b/frontend/src/reducers/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import questionReducer from './questionsSlice'
+
+const store = configureStore({
+  reducer: {
+    questions: questionReducer
+  }
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export default store;


### PR DESCRIPTION
- Redux maintains a store of original questions (fetched from the backend)
   - We expose a selector `selectFilteredQuestions` to compute a new filtered array from the current store.
   - This selector accepts a `filter`
   
- On load, BankPage fetches an array of filtered questions using the selector defined above.
  - BankPage also keeps track of a `filter` state object and passes the `setFilter` method to the FilterBar for FilterBar to manipulate the `filter` state
  - Upon change of the `filter` object, BankPage re-renders, and refetches the array of filtered questions again with the selector, but using the new filter
  
- Simply pass the filtered array to the QnTable each time for profit